### PR TITLE
ci: exclude generated changelog from formatting

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   ...ultracite,
   ignorePatterns: [
     ...(ultracite.ignorePatterns ?? []),
+    "CHANGELOG.md",
     "coverage/**",
     "lib/**",
   ],


### PR DESCRIPTION
## What changed

- Exclude `CHANGELOG.md` from Oxfmt through the existing `ignorePatterns` configuration.

## Why

Release Please owns and regenerates the changelog. Its generated Markdown differs from Oxfmt's preferred formatting, which caused the automated 3.0.0 release PR to fail the `Check` job even though the package code and release metadata were valid.

## Impact

Source, tests, documentation, package metadata, and workflow files remain formatting-checked. Only the bot-generated changelog is excluded, preventing future release PRs from failing on formatting churn.

## Validation

- `bun run check`
- 15 Jest tests passed
- strict TypeScript, Oxlint, package validation, actionlint, and zizmor passed
- direct `oxfmt --check CHANGELOG.md` confirms the file is excluded by the configured ignore rule
